### PR TITLE
feat: allow editing stores and assign manager

### DIFF
--- a/backend/routes/tiendas.js
+++ b/backend/routes/tiendas.js
@@ -33,5 +33,28 @@ router.get('/vista', async (req, res) => {
   }
 });
 
+// Actualizar una tienda existente y asignar jefe
+router.put('/:id', async (req, res) => {
+  const { id } = req.params;
+  const { nombre, direccion, id_jefe } = req.body;
+
+  try {
+    await db('Tiendas')
+      .where({ id_tienda: id })
+      .update({ nombre, direccion, id_jefe: id_jefe || null });
+
+    if (id_jefe) {
+      await db('Usuarios')
+        .where({ id_usuario: id_jefe })
+        .update({ rol: 'jefe' });
+    }
+
+    res.json({ mensaje: 'Tienda actualizada correctamente' });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Error al actualizar tienda' });
+  }
+});
+
 
 module.exports = router;

--- a/frontend/editar-tienda.html
+++ b/frontend/editar-tienda.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Editar Tienda</title>
+</head>
+<body>
+  <h1>Editar Tienda</h1>
+
+  <label for="selectTienda">Selecciona una tienda:</label>
+  <select id="selectTienda"></select>
+
+  <form id="formEditar">
+    <input type="text" id="nombre" placeholder="Nombre" required><br>
+    <input type="text" id="direccion" placeholder="Dirección"><br>
+    <label for="jefe">Jefe de tienda:</label>
+    <select id="jefe">
+      <option value="">Sin jefe</option>
+    </select><br>
+    <button type="submit">Guardar cambios</button>
+  </form>
+
+  <script>
+    const selectTienda = document.getElementById('selectTienda');
+    const selectJefe = document.getElementById('jefe');
+    let tiendas = [];
+
+    async function cargarDatos() {
+      tiendas = await fetch('http://localhost:3000/api/tiendas').then(r => r.json());
+      const usuarios = await fetch('http://localhost:3000/api/usuarios').then(r => r.json());
+
+      tiendas.forEach(t => {
+        const opt = document.createElement('option');
+        opt.value = t.id_tienda;
+        opt.textContent = t.nombre;
+        selectTienda.appendChild(opt);
+      });
+
+      usuarios.forEach(u => {
+        const opt = document.createElement('option');
+        opt.value = u.id_usuario;
+        opt.textContent = `${u.nombre} (${u.rol})`;
+        selectJefe.appendChild(opt);
+      });
+
+      if (tiendas.length) {
+        selectTienda.value = tiendas[0].id_tienda;
+        rellenarFormulario(tiendas[0]);
+      }
+    }
+
+    function rellenarFormulario(tienda) {
+      document.getElementById('nombre').value = tienda.nombre;
+      document.getElementById('direccion').value = tienda.direccion || '';
+      selectJefe.value = tienda.id_jefe || '';
+    }
+
+    selectTienda.addEventListener('change', e => {
+      const tienda = tiendas.find(t => t.id_tienda == e.target.value);
+      if (tienda) rellenarFormulario(tienda);
+    });
+
+    document.getElementById('formEditar').addEventListener('submit', async e => {
+      e.preventDefault();
+      const id = selectTienda.value;
+      const data = {
+        nombre: document.getElementById('nombre').value,
+        direccion: document.getElementById('direccion').value,
+        id_jefe: selectJefe.value || null
+      };
+      const res = await fetch(`http://localhost:3000/api/tiendas/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
+      const json = await res.json();
+      alert(json.mensaje || json.error);
+    });
+
+    cargarDatos();
+  </script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,7 @@
   <ul>
     <li><a href="crear-trabajador.html">Crear Trabajador</a></li>
     <li><a href="crear-tienda.html">Crear Tienda</a></li>
+    <li><a href="editar-tienda.html">Editar Tienda</a></li>
     <li><a href="ver-tiendas.html">Ver Tiendas</a></li>
     <li><a href="ver-usuarios.html">Ver Usuarios</a></li>
     <li><a href="asignar-turnos.html">Asignar Turnos</a></li>


### PR DESCRIPTION
## Summary
- add backend update route to modify stores and set manager role automatically
- new frontend page to edit store data and assign manager
- link edit page from homepage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f47e459c8332be65c4347d32de6f